### PR TITLE
Break out socket ops on Blender side

### DIFF
--- a/mh_sync_mesh/SyncMeshOperator.py
+++ b/mh_sync_mesh/SyncMeshOperator.py
@@ -6,37 +6,23 @@ bl_info = {
     "category": "Mesh",
 }
 
+from .SyncOperator import *
+
 import bpy
-import json
 import pprint
-import socket
 
 pp = pprint.PrettyPrinter(indent=4)
 
-class SyncMHMeshOperator(bpy.types.Operator):
+class SyncMHMeshOperator(SyncOperator):
     """Synchronize the shape of a human with MH"""
     bl_idname = "mesh.sync_mh_mesh"
     bl_label = "Synchronize MH Mesh"
     bl_options = {'REGISTER', 'UNDO'}
 
-    def executeJsonCall(self,jsoncall):
-        
-        client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        client.connect(('127.0.0.1', 12345))
-        client.send(jsoncall)
-     
-        data = ""
-    
-        while True:
-            buf = client.recv(1024)
-            if len(buf) > 0:
-                data += buf.strip().decode('utf-8')
-            else:
-                break
-    
-        return data;
+    def __init__(self):
+        super().__init__('getCoord', 'MESH')
 
-    def updateMesh(self,json_obj):
+    def callback(self,json_obj):
 
         print("Update mesh")
 
@@ -74,19 +60,3 @@ class SyncMHMeshOperator(bpy.types.Operator):
     #            bfile.write("{0:.8f}".format(v.co[1]))
     #            bfile.write(" ],\n")
     #        bfile.write("] } \n")
-
-    def execute(self, context):
-        print("Execute syncmesh")
-        
-        obj = context.object
-        if obj is None or not obj.type == 'MESH':
-            self.report({'ERROR'}, "Must select mesh to synchronize")
-        else:
-            #self.dumpObj()
-            json_raw = self.executeJsonCall(b'getCoord')
-            #with open("/tmp/json.json","w") as jfile:
-            #    jfile.write(json_raw)
-            json_obj = json.loads(json_raw)
-            self.updateMesh(json_obj)
-
-        return {'FINISHED'} 

--- a/mh_sync_mesh/SyncOperator.py
+++ b/mh_sync_mesh/SyncOperator.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import bpy
+import json
+import pprint
+import socket
+
+pp = pprint.PrettyPrinter(indent=4)
+
+class SyncOperator(bpy.types.Operator):
+    def __init__(self, operator, requiredType):
+        self.operator = operator
+        self.requiredType = requiredType
+
+    def executeJsonCall(self):     
+        client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        client.connect(('127.0.0.1', 12345))
+        client.send(bytes(self.operator, 'utf-8'))
+     
+        data = ""
+    
+        while True:
+            buf = client.recv(1024)
+            if len(buf) > 0:
+                data += buf.strip().decode('utf-8')
+            else:
+                break
+    
+        return data;
+
+    def callback(self,json_obj):
+        raise 'needs to be overridden by subclass'
+
+    def execute(self, context):
+        print("Execute " + self.operator)
+        
+        obj = context.object
+
+        json_raw = self.executeJsonCall()
+        #with open("/tmp/json.json","w") as jfile:
+        #    jfile.write(json_raw)
+        json_obj = json.loads(json_raw)
+        self.callback(json_obj)
+
+        return {'FINISHED'} 
+
+    @classmethod
+    def poll(cls, context):
+        ob = context.object
+        return ob and ob.type == self.requiredType

--- a/mh_sync_mesh/__init__.py
+++ b/mh_sync_mesh/__init__.py
@@ -16,11 +16,13 @@ bl_info = {
 if "bpy" in locals():
     print("Reloading plugin")
     import imp
+    imp.reload(SyncOperator)
     imp.reload(SyncMeshOperator)
     imp.reload(SyncPanel)
 else:
     print("Loading plugin")
 
+    from . import SyncOperator
     from . import SyncMeshOperator
     from . import SyncPanel
 


### PR DESCRIPTION
Only changed Blender side.  Module loaded on Blender.  Operation failed
when clicking with connection refused.  MH log showed:

Could not load 8_server_socket
Traceback (most recent call last):
  File "./core/mhmain.py", line 539, in loadPlugin
    module.load(self)
AttributeError: 'module' object has no attribute 'load'