### PR TITLE
avoid crash when adding materials to a mesh without detailed helper

### DIFF
--- a/blender_source/MH_Community/mh_sync/import_body_binary.py
+++ b/blender_source/MH_Community/mh_sync/import_body_binary.py
@@ -323,7 +323,9 @@ class ImportBodyBinary():
             mask.show_in_editmode = True
             mask.show_on_cage = True
 
-        if self.addSimpleMaterials:
+        # since we need groups to color the body materials are only added when groups are created
+        #
+        if self.detailedHelpers and self.addSimpleMaterials:
             bpy.ops.mh_community.add_simple_materials()
 
         self._profile("handleHelpers")

--- a/blender_source/MH_Community/mh_sync/importer_ui.py
+++ b/blender_source/MH_Community/mh_sync/importer_ui.py
@@ -126,7 +126,8 @@ def addImporterSettingsToTab(layout, scn):
     helperBox.label(text="How to handle helpers")
     helperBox.prop(scn, 'MhHandleHelper', text="")
     helperBox.prop(scn, 'MhDetailedHelpers', text="Detailed helper groups")
-    helperBox.prop(scn, 'MhAddSimpleMaterials', text="Simple Materials for Helpers")
+    if scn.MhDetailedHelpers:
+        helperBox.prop(scn, 'MhAddSimpleMaterials', text="Simple Materials for Helpers")
 
     #importHumanBox.separator()
     #importHumanBox.label(text="Body hidden faces:")


### PR DESCRIPTION
vertex-groups

in case of non existent detailed helper vertex-groups the creation of materials
crashed (joint-ground was not there and the poll function crashed with a
context error which will not even fit on the blender page ...)

There are only 3 groups existent, when the detailed groups are not created.
It also would be possible to only color them, but the benefit isn't that
big :)

So I decided to hide the materials checkbox until the detailed helper
is selected. That's easier for the user.

To avoid a crash anyway, we need to check for the detailed
helpers always (other way to crash it: switch on detailed groups, switch on material, switch off
detailed groups ...)